### PR TITLE
Disable integration test for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     environment:
       name: integration
 
+    if: false
     steps:
       - name: Checkout
         id: checkout
@@ -62,8 +63,8 @@ jobs:
         id: configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: 'arn:aws:iam::640168443522:role/aws-ssm-update-association-ci'
-          aws-region: 'eu-central-1'
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
           audience: 'sts.amazonaws.com'
 
       - name: Get latest NixOS image


### PR DESCRIPTION
We need to create a dedicated AWS account for this. It was currently running on my personal account.
